### PR TITLE
Security advisory dependency bumps

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -119,7 +119,7 @@ GEM
     minitest (6.0.5)
       drb (~> 2.0)
       prism (~> 1.5)
-    net-imap (0.6.4)
+    net-imap (0.6.4.1)
       date
       net-protocol
     net-pop (0.1.2)
@@ -235,4 +235,4 @@ DEPENDENCIES
   rspec-rails
 
 BUNDLED WITH
-   2.5.9
+  4.0.11


### PR DESCRIPTION
Bumps net-imap to 0.6.4.1 (moneybird/security-advisory-monitor#5380)